### PR TITLE
MAIN-8926 | adding attachToDocument parameter

### DIFF
--- a/addon/components/pop-over.js
+++ b/addon/components/pop-over.js
@@ -73,6 +73,12 @@ export default Ember.Component.extend({
 
   on: null,
 
+  /**
+   * Attaching events to document instead of attaching them directly to elements
+   * It's better to leave it set to false for better performance
+   */
+  attachToDocument: false,
+
   addTarget(target, options) {
     get(this, 'targets').pushObject(Target.create(options, {
       component: this,
@@ -132,7 +138,8 @@ export default Ember.Component.extend({
     // Add implicit target
     if (get(this, 'for') && get(this, 'on')) {
       this.addTarget(get(this, 'for'), {
-        on: get(this, 'on')
+        on: get(this, 'on'),
+        attachToDocument: get(this, 'attachToDocument')
       });
     }
 

--- a/addon/system/target.js
+++ b/addon/system/target.js
@@ -123,6 +123,7 @@ var Target = Ember.Object.extend(Ember.Evented, {
   attach: function () {
     var element = getElementForTarget(this.target);
     var $element = $(element);
+    var $document = $(document);
 
     // Already attached or awaiting an element to exist
     if (get(this, 'attached') || element == null) { return; }
@@ -137,35 +138,65 @@ var Target = Ember.Object.extend(Ember.Evented, {
     }
 
     var eventManager = this.eventManager;
+    var events = keys(eventManager);
+    var labelSelector = getLabelSelector($element);
 
-    keys(eventManager).forEach(function (event) {
-      $element.on(event, eventManager[event]);
-    });
-
-    var selector = getLabelSelector($element);
-    if (selector) {
-      keys(eventManager).forEach(function (event) {
-        $(selector).on(event, eventManager[event]);
+    if(this.attachToDocument) {
+      events.forEach(function (event) {
+        $document.on(event, `#${id}`, eventManager[event]);
       });
+
+      if (labelSelector) {
+        events.forEach(function (event) {
+          $document.on(event, labelSelector, eventManager[event]);
+        });
+      }
+    } else {
+      events.forEach(function (event) {
+        $element.on(event, eventManager[event]);
+      });
+
+      if (labelSelector) {
+        events.forEach(function (event) {
+          $(labelSelector).on(event, eventManager[event]);
+        });
+      }
     }
+
+
   },
 
   detach: function () {
     var element = this.element;
     var $element = $(element);
+    var $document = $(document);
 
     var eventManager = this.eventManager;
+    var events = keys(eventManager);
+    var labelSelector = getLabelSelector($element);
 
     var id = $element.attr('id');
-    keys(eventManager).forEach(function (event) {
-      $element.off(event, eventManager[event]);
-    });
 
-    var selector = getLabelSelector($element);
-    if (selector) {
-      keys(eventManager).forEach(function (event) {
-        $(selector).off(event, eventManager[event]);
+    if(this.attachToDocument) {
+      events.forEach(function (event) {
+        $document.off(event, `#${id}`, eventManager[event]);
       });
+
+      if (labelSelector) {
+        events.forEach(function (event) {
+          $document.off(event, labelSelector, eventManager[event]);
+        });
+      }
+    } else {
+      events.forEach(function (event) {
+        $element.off(event, eventManager[event]);
+      });
+
+      if (labelSelector) {
+        events.forEach(function (event) {
+          $(labelSelector).off(event, eventManager[event]);
+        });
+      }
     }
 
     // Remove references for GC


### PR DESCRIPTION
@kvas-damian 
We need to parameterize if we want to attach events to directly to elements or to document. Usually it is better (for performance) to attach events directly to elements but in some specific situations we have to attach events to document.
